### PR TITLE
Empty name bugfix

### DIFF
--- a/pyspades/contained.pyx
+++ b/pyspades/contained.pyx
@@ -318,7 +318,10 @@ cdef class ExistingPlayer(Loader):
         self.tool = reader.readByte(True)
         self.kills = reader.readInt(True, False)
         self.color = read_color(reader)
-        self.name = decode(reader.readString()) # 16 bytes
+        try:
+            self.name = decode(reader.readString()) # 16 bytes
+        except:
+            self.name = "Deuce"
 
     cpdef write(self, ByteWriter writer):
         writer.writeByte(self.id, True)


### PR DESCRIPTION
Before, people with empty names were stuck in limbo view and the server was showing an IndexError: index out of range.
This will allow people with an empty name to join with the name Deuce.