### PR TITLE
player.py: Cap grenade fuse at 3.0s

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -419,6 +419,8 @@ class ServerConnection(BaseConnection):
         self.grenades -= 1
         if not self.check_speedhack(*contained.position):
             contained.position = self.world_object.position.get()
+        if contained.value > 3.0: # fuse cannot be greater than 3.0s
+            contained.value = 3.0
         velocity = Vertex3(*contained.velocity) - self.world_object.velocity
         if velocity.length() > 2.0: # cap at tested maximum
             velocity = velocity.normal() * 2.0


### PR DESCRIPTION
Only hacked clients can send a grenade that lasts longer than 3s.

## Changes
- **player.py** Limits the fuse of grenades sent by players to 3.0 seconds
