### PR TITLE
pyspades/player.py: Better sync refill packets between clients

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -798,10 +798,16 @@ class ServerConnection(BaseConnection):
         self.hp = 100
         self.grenades = 3
         self.blocks = 50
-        self.weapon_object.restock()
+        self.weapon_object.reset()
         if not local:
             restock = loaders.Restock()
             self.send_contained(restock)
+            if self.client_info and self.client_info["client"] == "Ace of Spades" or not self.client_info:
+                weapon_reload = loaders.WeaponReload()
+                weapon_reload.player_id = self.player_id
+                weapon_reload.clip_ammo = self.weapon_object.current_ammo
+                weapon_reload.reserve_ammo = self.weapon_object.current_stock
+                self.send_contained(weapon_reload)
 
     def respawn(self) -> None:
         if self.spawn_call is None:


### PR DESCRIPTION
Both BetterSpades and OpenSpades give after a refill the full amount of bullets in the current ammo (basically resetting the magazine) plus a full reserve ammo, while the original voxlap client assumes that just the reserve ammo gets updated. This gives the voxlap client some disadvantage. Now its the question, do we adapt the both open source clients to the example of voxlap or vice versa. I think both opinions are valid, but what we can agree on is that it should be equally between the clients. Here I just adapted to the handling of OpenSpades and BetterSpades, because I believe that the majority of AoS players is now used to get a full current_ammo on refill. Therefore I added an additional check that sends voxlap a reload packet, so that it gets the same value. Testing still required. This additionally fixes desyncs between clients and server. For example on arena, you are the last man standing, get teleported back to your fence and get a refill packet. Before, the server assumed your last known current_ammo, making the last shots of your current_ammo of OpenSpades and BetterSpades invalid that you actually hit. With this fix, the ammo should be better synced across server and client as well as the clients.