### PR TITLE
feat(irc): add opnames option

### DIFF
--- a/piqueserver/irc.py
+++ b/piqueserver/irc.py
@@ -141,7 +141,9 @@ class IRCBot(irc.IRCClient):
 
     @channel
     def privmsg(self, user, irc_channel, msg):
-        if user not in self.ops and user not in self.voices:
+        if (user not in self.ops and
+            user not in self.voices and
+            user not in self.factory.opnames):
             return  # This user is unpriviledged
 
         prefix = '@' if user in self.ops else '+'
@@ -154,7 +156,8 @@ class IRCBot(irc.IRCClient):
             message = ("[irc] <{}> {}".format(prefix + alias, msg))[:max_len]
             log.info(escape_control_codes(message))
             self.factory.server.broadcast_chat(message)
-        elif msg.startswith(self.factory.commandprefix) and user in self.ops:
+        elif (msg.startswith(self.factory.commandprefix) and
+              (user in self.ops) or (user in self.factory.opnames)):
             self.unaliased_name = user
             self.name = prefix + alias
             user_input = msg[len(self.factory.commandprefix):]
@@ -228,6 +231,7 @@ class IRCClientFactory(protocol.ClientFactory):
         self.commandprefix = config.get('commandprefix', '.')
         self.chatprefix = config.get('chatprefix', '')
         self.password = config.get('password', '') or None
+        self.opnames = config.get('opnames', [])
 
     def startedConnecting(self, connector):
         log.info("Connecting to IRC server...")


### PR DESCRIPTION
This is very useful for internal (NON-public-facing) IRC servers that don't have a database for keeping track of users.
