### PR TITLE
fix(world_c): ftol(): revert to PySnip's regular cast to float

### DIFF
--- a/pyspades/world_c.cpp
+++ b/pyspades/world_c.cpp
@@ -121,7 +121,7 @@ int validate_hit(float shooter_x, float shooter_y, float shooter_z,
 // silly VOXLAP function
 inline void ftol(float f, long *a)
 {
-    *a = (long)floor(f + 0.5f);
+    *a = (long) f;
 }
 
 //same as isvoxelsolid but water is empty && out of bounds returns true


### PR DESCRIPTION
`floor(f + 0.5f)` was supposed to help replicate VOXLAP's behavior, however it seems to break physics more than anything. So I'm reverting that change.