### PR TITLE
Correct output of /client when used on ace users

### DIFF
--- a/pyspades/player.py
+++ b/pyspades/player.py
@@ -727,7 +727,7 @@ class ServerConnection(BaseConnection):
         self.client_info["version"] = contained.version
         self.client_info["os_info"] = contained.os_info[:108]
         client_names = {
-            ord('a') : "Ace of Spades",
+            ord('a') : "ACE",
             ord('o') : "OpenSpades",
             ord('B') : "BetterSpades",
             ord('V') : "Voxenium",


### PR DESCRIPTION
The ace client is by 10se1ucgo; https://github.com/10se1ucgo/ace
This changes the output of /client to reflect the actual client used.

See also: https://github.com/10se1ucgo/ace/blob/d485a6efb4e6b06f12608d214bc9a998f2e76e48/src/net/net.cpp#L191